### PR TITLE
Specify requires fields

### DIFF
--- a/facebook.rb
+++ b/facebook.rb
@@ -20,7 +20,9 @@ def formatted_posts(posts)
 end
 
 def page_info(page_name)
-  info = @graph.get_object(page_name, {}, {:use_ssl => true})
+  info = @graph.get_object(page_name,
+                           {fields: ['likes', 'checkins', 'talking_about_count']},
+                           {:use_ssl => true})
   {
     likes: info['likes'],
     checkins: info['checkins'],


### PR DESCRIPTION
Otherwise Facebook will just return the page Name and ID. See also
http://stackoverflow.com/questions/31634408/facebook-graph-api-returns-only-name-and-id-for-some-websites
